### PR TITLE
Move to generic key/value pairs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,35 +6,55 @@ This implementation only holds pointers to provided key and value pairs; it is t
 Collisions are handled with linear probing, for the sake of simplicity and locality(?).</br>
 No removal implemented, yet to be decided if it's necessary.
 
+*Opaque macro version for ease-of-use*
 ```c
+#include <stdio.h>
+#include <string.h>
 #include "hash_map.h"
 
 int main(void)
 {
-	/* Hash map structs */
 	struct hash_map map;
 	struct hash_map_iter iter;
-	/* Data variables */
-	int passcode;
-	int age;
-	/* Pointers for data access */
+	/* Data */
+	const char *strings[] = {"alpha", "beta", "gamma", "epsilon", "delta"};
+	int nums[] = {83, 2, 3, 4, 5};
+	/* Data accessors */
 	char *key;
-	int *value;
+	void *val;
 
-	passcode = 2928;
-	age = 76;
-	/* If we do not provide an allocator descriptor, the map will use the standard library. */
-	hash_map_init(&map, NULL);
+	HASH_MAP_INIT(&map, HASH_MAP_KEY_TYPE_STRING);
+	HASH_MAP_INSERT(&map, strings[0], strlen(strings[0]) + 1, &nums[0],
+		sizeof(nums[0]));
+	HASH_MAP_INSERT(&map, strings[0], strlen(strings[0]) + 1, &nums[0],
+		sizeof(nums[0]));
+	HASH_MAP_INSERT(&map, strings[1], strlen(strings[1]) + 1, &nums[1],
+		sizeof(nums[1]));
+	HASH_MAP_INSERT(&map, strings[2], strlen(strings[2]) + 1, &nums[2],
+		sizeof(nums[2]));
+	HASH_MAP_INSERT(&map, strings[3], strlen(strings[3]) + 1, &nums[3],
+		sizeof(nums[3]));
+	HASH_MAP_INSERT(&map, strings[4], strlen(strings[4]) + 1, &nums[4],
+		sizeof(nums[4]));
 	hash_map_iter_init(&iter, &map);
-	hash_map_insert(&map, "passcode", &passcode);
-	hash_map_insert(&map, "age", &age);
-	HASH_MAP_ITER_FOR_EACH(&iter, key, value) {
-		printf("%s : %d\n", key, (*value));
+	HASH_MAP_ITER_FOR_EACH(&iter, key, val) {
+		printf("%s : %d\n", key, *(int *)val);
 	}
-	HASH_MAP_AT(&map, "passcode", value);
 	hash_map_iter_finish(&iter);
 	hash_map_finish(&map);
 	return 0;
 }
 ```
-TODO: Actually store value data into the hash_map, not just pointers to the data.
+
+*Explicit function version*
+```c
+#include <stdio.h>
+#include <string.h>
+#include "hash_map.h"
+
+int main(void)
+{
+	/* TODO */
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # hash_map_c
-Naive and portable implementation of a hash map written in ANSI C99, using the FNV1a hash function.</br>
+Naive and portable implementation of a hash map (view) written in C99, using the FNV1a hash function.</br>
 Made as an exercise and for personal use in hobby projects.
 
-This implementation only holds pointers to provided key and value pairs; it is the user's responsibility to maintain the data.</br>
+This implementation only holds pointers to key and value pairs; no copying occurs, therefore it is the user's responsibility to maintain the data.</br>
 Collisions are handled with linear probing, for the sake of simplicity and locality(?).</br>
-No removal implemented, yet to be decided if it's necessary.
+No removal implemented, to be considered.</br>
 
 *Opaque macro version for ease-of-use*
 ```c

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,6 @@
 
 1. More macros to reduce argument boilerplate code for the user.
 2. Explicit functions that do checks against previously established sizes etc.
-	1. *hash_map_insert_ex(struct hash_map *map, void *key, void *value, size_t key_size, size_t value_size)*
+	1. *hash_map_insert_ex(struct hash_map \*map, void \*key, void \*value, size_t key_size, size_t value_size)*
 		- This will compare passed sizes with those defined at hash map creation.
 		- We can wrap them in macros HASH_MAP_INSERT(map, key, value).

--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,4 @@
 	1. *hash_map_insert_ex(struct hash_map \*map, void \*key, void \*value, size_t key_size, size_t value_size)*
 		- This will compare passed sizes with those defined at hash map creation.
 		- We can wrap them in macros HASH_MAP_INSERT(map, key, value).
+3. Clean up codebase, several reworks lowered code quality for quick results.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,7 @@
+# TODO
+
+1. More macros to reduce argument boilerplate code for the user.
+2. Explicit functions that do checks against previously established sizes etc.
+	1. *hash_map_insert_ex(struct hash_map *map, void *key, void *value, size_t key_size, size_t value_size)*
+		- This will compare passed sizes with those defined at hash map creation.
+		- We can wrap them in macros HASH_MAP_INSERT(map, key, value).

--- a/hash_map.c
+++ b/hash_map.c
@@ -308,7 +308,7 @@ void hash_map_insert(struct hash_map *map, const void *key, size_t key_size,
 	const void *value, size_t value_size)
 {
 
-	if (!map || !key || !IS_VALID_MAP_SET(map->set)
+	if (!map || !key || !value || !IS_VALID_MAP_SET(map->set)
 			|| !IS_VALID_KEY_TYPE(map->key_type)) {
 		return;
 	}
@@ -342,7 +342,7 @@ int hash_map_at(const struct hash_map *map, const void *key, size_t key_size,
 {
 	uint64_t index;
 
-	if (!map || !IS_VALID_MAP_SET(map->set)) {
+	if (!map || !IS_VALID_MAP_SET(map->set) || !key || !value) {
 		return 0;
 	}
 	index = calc_index(key, key_size, map->set.capacity);
@@ -394,7 +394,8 @@ int hash_map_iter_next(struct hash_map_iter *iter, const void **key,
 {
 	/* NOTE: This function should NOT be used explicitly, it is intended as
 	 * an internal function for helper macros. */
-	if (!iter || !key || !value) {
+	if (!iter || !iter->map || !IS_VALID_MAP_SET(iter->map->set)
+			|| !key || !value) {
 		return 0;
 	}
 	/* TODO: Implement iterator invalidation, tracking 'seen' elements. */

--- a/hash_map.c
+++ b/hash_map.c
@@ -1,7 +1,6 @@
 #include <float.h>
 #include <math.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include "hash_map.h"
@@ -14,10 +13,6 @@
 	((desc).alloc_ctx_cb && (desc).dealloc_ctx_cb && (desc).ctx)
 #define HAS_VALID_MALLOC_AND_FREE(desc) \
 	((desc).malloc_cb && (desc).free_cb)
-#define IS_VALID_ENTRY_DESC(desc) \
-	(((desc).key_type > HASH_MAP_KEY_TYPE_UNDEFINED \
-			&& (desc).key_type < HASH_MAP_KEY_TYPE_NUM_OF) \
-			&& (desc).key_size && (desc).value_size)
 #define IS_VALID_MAP_SET(set) \
 	((set).entries && (set).capacity)
 #define IS_VALID_KEY_TYPE(type) \
@@ -163,7 +158,6 @@ static int compare_float(const void *lhs, const void *rhs, size_t size)
 
 static int compare_string(const void *lhs, const void *rhs, size_t size)
 {
-	printf("%s, %s.\n", (const char *)lhs, (const char *)rhs);
 	return strncmp((const char *) lhs, (const char *) rhs, size);
 }
 

--- a/hash_map.c
+++ b/hash_map.c
@@ -166,7 +166,7 @@ static int compare_ptr(const void *lhs, const void *rhs, size_t size)
 	return (lhs > rhs) ? 1 : ((lhs < rhs) ? -1 : 0);
 }
 
-static uint64_t hash(void *key, size_t key_size)
+static uint64_t hash(const void *key, size_t key_size)
 {
 	uint64_t hash = FNV_OFFSET;
 	const unsigned char *data = key;
@@ -178,7 +178,7 @@ static uint64_t hash(void *key, size_t key_size)
 	return hash;
 }
 
-static uint64_t calc_index(char *key, size_t key_size, uint64_t capacity)
+static uint64_t calc_index(const void *key, size_t key_size, uint64_t capacity)
 {
 	return (uint64_t) (hash(key, key_size) & (capacity - 1));
 }
@@ -198,8 +198,8 @@ static struct hash_map_set make_map_set(const size_t capacity,
 	return set;
 }
 
-static void set_map_entry(struct hash_map *map, void *key, size_t key_size,
-	void *value, size_t value_size)
+static void set_map_entry(struct hash_map *map, const void *key,
+	size_t key_size, const void *value, size_t value_size)
 {
 	uint64_t index;
 
@@ -304,8 +304,8 @@ void hash_map_finish(struct hash_map *map)
 	}
 }
 
-void hash_map_insert(struct hash_map *map, void *key, size_t key_size,
-	void *value, size_t value_size)
+void hash_map_insert(struct hash_map *map, const void *key, size_t key_size,
+	const void *value, size_t value_size)
 {
 
 	if (!map || !key || !IS_VALID_MAP_SET(map->set)
@@ -337,8 +337,8 @@ void hash_map_insert(struct hash_map *map, void *key, size_t key_size,
 	map->set.size++;
 }
 
-int hash_map_at(const struct hash_map *map, void *key, size_t key_size,
-	void **value)
+int hash_map_at(const struct hash_map *map, const void *key, size_t key_size,
+	const void **value)
 {
 	uint64_t index;
 
@@ -389,7 +389,8 @@ void hash_map_iter_finish(struct hash_map_iter *iter)
 	}
 }
 
-int hash_map_iter_next(struct hash_map_iter *iter, char **key, void **value)
+int hash_map_iter_next(struct hash_map_iter *iter, const void **key,
+	const void **value)
 {
 	/* NOTE: This function should NOT be used explicitly, it is intended as
 	 * an internal function for helper macros. */

--- a/hash_map.c
+++ b/hash_map.c
@@ -167,9 +167,9 @@ static int compare_ptr(const void *lhs, const void *rhs, size_t size)
 	return (lhs > rhs) ? 1 : ((lhs < rhs) ? -1 : 0);
 }
 
-static unsigned long long hash(void *key)
+static uint64_t hash(void *key)
 {
-	unsigned long long hash;
+	uint64_t hash;
 
 	hash = FNV_OFFSET;
 	/* TODO: Implement a range check based on key size param. */
@@ -180,9 +180,9 @@ static unsigned long long hash(void *key)
 	return hash;
 }
 
-static unsigned long long calc_index(char *key, unsigned long long capacity)
+static uint64_t calc_index(char *key, unsigned long long capacity)
 {
-	return (unsigned long long) (hash(key) & (capacity - 1));
+	return (uint64_t) (hash(key) & (capacity - 1));
 }
 
 static struct hash_map_set make_map_set(const size_t capacity,
@@ -203,7 +203,7 @@ static struct hash_map_set make_map_set(const size_t capacity,
 static void set_map_entry(struct hash_map *map, void *key, size_t key_size,
 	void *value, size_t value_size)
 {
-	unsigned long long index;
+	uint64_t index;
 
 	/* NOTE: We expect a valid key, which should have been verified by
 	 * the caller function. */
@@ -341,7 +341,7 @@ void hash_map_insert(struct hash_map *map, void *key, size_t key_size,
 
 int hash_map_at(const struct hash_map *map, void *key, void **value)
 {
-	unsigned long long index;
+	uint64_t index;
 
 	if (!map || !IS_VALID_MAP_SET(map->set)) {
 		return 0;
@@ -397,6 +397,7 @@ int hash_map_iter_next(struct hash_map_iter *iter, char **key, void **value)
 	if (!iter || !key || !value) {
 		return 0;
 	}
+	/* TODO: Implement iterator invalidation, tracking 'seen' elements. */
 	while (iter->index < iter->map->set.capacity) {
 		if (iter->map->set.entries[iter->index].key != NULL) {
 			*key = iter->map->set.entries[iter->index].key;

--- a/hash_map.h
+++ b/hash_map.h
@@ -9,11 +9,12 @@
 #define HASH_MAP_INIT(map, key_type) \
 	hash_map_init(map, key_type, NULL, NULL)
 #define HASH_MAP_INSERT(map, key, key_size, value, value_size) \
-	hash_map_insert(map, (void *) key, key_size, (void *) value, value_size)
+	hash_map_insert(map, (const void *) key, key_size, \
+		(const void *) value, value_size)
 #define HASH_MAP_AT(map, key, key_size, value) \
-	hash_map_at(map, key, key_size, (void *) &(value))
+	hash_map_at(map, key, key_size, (const void *) &(value))
 #define HASH_MAP_ITER_FOR_EACH(iter, key, value) \
-	for (; hash_map_iter_next(iter, &(key), (void **) &(value)); )
+	for (; hash_map_iter_next(iter, (void *) &(key), (const void **) &(value)); )
 
 enum hash_map_key_type {
 	HASH_MAP_KEY_TYPE_UNDEFINED,
@@ -31,7 +32,7 @@ enum hash_map_key_type {
 
 struct hash_map_trait_desc {
 	int (*compare)(const void *, const void *, size_t);
-	uint64_t (*hash)(void *, size_t);
+	uint64_t (*hash)(const void *, size_t);
 };
 
 struct hash_map_alloc_desc {
@@ -43,8 +44,8 @@ struct hash_map_alloc_desc {
 };
 
 struct hash_map_entry {
-	void *key;
-	void *value;
+	const void *key;
+	const void *value;
 	size_t key_size;
 	size_t value_size;
 };
@@ -71,14 +72,15 @@ void hash_map_init(struct hash_map *map, enum hash_map_key_type key_type,
 	struct hash_map_trait_desc *trait_desc,
 	struct hash_map_alloc_desc *alloc_desc);
 void hash_map_finish(struct hash_map *map);
-void hash_map_insert(struct hash_map *map, void *key, size_t key_size,
-	void *value, size_t value_size);
-int hash_map_at(const struct hash_map *map, void *key, size_t key_size,
-	void **value);
+void hash_map_insert(struct hash_map *map, const void *key, size_t key_size,
+	const void *value, size_t value_size);
+int hash_map_at(const struct hash_map *map, const void *key, size_t key_size,
+	const void **value);
 size_t hash_map_size(const struct hash_map *map);
 size_t hash_map_capacity(const struct hash_map *map);
 void hash_map_iter_init(struct hash_map_iter *iter, struct hash_map *map);
 void hash_map_iter_finish(struct hash_map_iter *iter);
-int hash_map_iter_next(struct hash_map_iter *iter, char **key, void **value);
+int hash_map_iter_next(struct hash_map_iter *iter, const void **key,
+	const void **value);
 
 #endif

--- a/hash_map.h
+++ b/hash_map.h
@@ -2,14 +2,18 @@
 #define HASH_MAP_H
 
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 /* NOTE: Address-of operators in macros might lead to unexpected behaviour. */
-#define HASH_MAP_AT(map, key, value) \
-	hash_map_at(map, key, (void *)&(value))
-#define HASH_MAP_ITER_FOR_EACH(iter, key, value) \
-	for (; hash_map_iter_next(iter, &(key), (void **)&(value)); )
+#define HASH_MAP_INIT(map, key_type) \
+	hash_map_init(map, key_type, NULL, NULL)
 #define HASH_MAP_INSERT(map, key, key_size, value, value_size) \
 	hash_map_insert(map, (void *) key, key_size, (void *) value, value_size)
+#define HASH_MAP_AT(map, key, key_size, value) \
+	hash_map_at(map, key, key_size, (void *) &(value))
+#define HASH_MAP_ITER_FOR_EACH(iter, key, value) \
+	for (; hash_map_iter_next(iter, &(key), (void **) &(value)); )
 
 enum hash_map_key_type {
 	HASH_MAP_KEY_TYPE_UNDEFINED,
@@ -27,7 +31,7 @@ enum hash_map_key_type {
 
 struct hash_map_trait_desc {
 	int (*compare)(const void *, const void *, size_t);
-	unsigned long long (*hash)(void *);
+	uint64_t (*hash)(void *, size_t);
 };
 
 struct hash_map_alloc_desc {
@@ -69,7 +73,8 @@ void hash_map_init(struct hash_map *map, enum hash_map_key_type key_type,
 void hash_map_finish(struct hash_map *map);
 void hash_map_insert(struct hash_map *map, void *key, size_t key_size,
 	void *value, size_t value_size);
-int hash_map_at(const struct hash_map *map, void *key, void **value);
+int hash_map_at(const struct hash_map *map, void *key, size_t key_size,
+	void **value);
 size_t hash_map_size(const struct hash_map *map);
 size_t hash_map_capacity(const struct hash_map *map);
 void hash_map_iter_init(struct hash_map_iter *iter, struct hash_map *map);

--- a/hash_map.h
+++ b/hash_map.h
@@ -3,12 +3,13 @@
 
 #include <stddef.h>
 
-#define HASH_MAP_INSERT(map, key, value) \
-	hash_map_insert(map, key, (void *)(value))
-#define HASH_MAP_AT(map, key, value) hash_map_at(map, key, (void *)&(value))
+/* NOTE: Address-of operators in macros might lead to unexpected behaviour. */
+#define HASH_MAP_AT(map, key, value) \
+	hash_map_at(map, key, (void *)&(value))
 #define HASH_MAP_ITER_FOR_EACH(iter, key, value) \
 	for (; hash_map_iter_next(iter, &(key), (void **)&(value)); )
-/* NOTE: Address-of operators in macro might lead to unexpected behaviour. */
+#define HASH_MAP_INSERT(map, key, key_size, value, value_size) \
+	hash_map_insert(map, (void *) key, key_size, (void *) value, value_size)
 
 enum hash_map_key_type {
 	HASH_MAP_KEY_TYPE_UNDEFINED,
@@ -20,7 +21,8 @@ enum hash_map_key_type {
 	HASH_MAP_KEY_TYPE_CHAR,
 	HASH_MAP_KEY_TYPE_STRING,
 	HASH_MAP_KEY_TYPE_PTR,
-	HASH_MAP_KEY_TYPE_CUSTOM
+	HASH_MAP_KEY_TYPE_CUSTOM,
+	HASH_MAP_KEY_TYPE_NUM_OF
 };
 
 struct hash_map_trait_desc {
@@ -39,15 +41,21 @@ struct hash_map_alloc_desc {
 struct hash_map_entry {
 	void *key;
 	void *value;
+	size_t key_size;
+	size_t value_size;
+};
+
+struct hash_map_set {
+	struct hash_map_entry *entries;
+	size_t size;
+	size_t capacity;
 };
 
 struct hash_map {
 	struct hash_map_trait_desc trait_desc;
 	struct hash_map_alloc_desc alloc_desc;
-	struct hash_map_entry *set;
+	struct hash_map_set set;
 	enum hash_map_key_type key_type;
-	size_t size;
-	size_t capacity;
 };
 
 struct hash_map_iter {
@@ -59,8 +67,9 @@ void hash_map_init(struct hash_map *map, enum hash_map_key_type key_type,
 	struct hash_map_trait_desc *trait_desc,
 	struct hash_map_alloc_desc *alloc_desc);
 void hash_map_finish(struct hash_map *map);
-void hash_map_insert(struct hash_map *map, char *key, void *value);
-int hash_map_at(const struct hash_map *map, char *key, void **value);
+void hash_map_insert(struct hash_map *map, void *key, size_t key_size,
+	void *value, size_t value_size);
+int hash_map_at(const struct hash_map *map, void *key, void **value);
 size_t hash_map_size(const struct hash_map *map);
 size_t hash_map_capacity(const struct hash_map *map);
 void hash_map_iter_init(struct hash_map_iter *iter, struct hash_map *map);

--- a/hash_map.h
+++ b/hash_map.h
@@ -10,23 +10,43 @@
 	for (; hash_map_iter_next(iter, &(key), (void **)&(value)); )
 /* NOTE: Address-of operators in macro might lead to unexpected behaviour. */
 
-struct hash_map_entry {
-	char *key;
-	void *value;
+enum hash_map_key_type {
+	HASH_MAP_KEY_TYPE_UNDEFINED,
+	HASH_MAP_KEY_TYPE_INT,
+	HASH_MAP_KEY_TYPE_UINT,
+	HASH_MAP_KEY_TYPE_FLOAT,
+	HASH_MAP_KEY_TYPE_DOUBLE,
+	HASH_MAP_KEY_TYPE_DOUBLE_LONG,
+	HASH_MAP_KEY_TYPE_CHAR,
+	HASH_MAP_KEY_TYPE_STRING,
+	HASH_MAP_KEY_TYPE_PTR
+};
+
+struct hash_map_trait_desc {
+	int (*compare)(void *, void *, size_t);
+	unsigned long long (*hash)(void *);
 };
 
 struct hash_map_alloc_desc {
-	void *(*alloc_cb)(size_t, void *);
-	void *(*realloc_cb)(void *, size_t, void *);
-	void (*dealloc_cb)(void *, void *);
-	void *allocator_ctx;
+	void *(*malloc_cb)(size_t);
+	void (*free_cb)(void *);
+	void *(*alloc_ctx_cb)(void *, size_t);
+	void (*dealloc_ctx_cb)(void *);
+	void *ctx;
+};
+
+struct hash_map_entry {
+	const void *key;
+	const void *value;
 };
 
 struct hash_map {
+	struct hash_map_trait_desc trait_desc;
+	struct hash_map_alloc_desc alloc_desc;
 	struct hash_map_entry *set;
+	enum hash_map_key_type key_type;
 	size_t size;
 	size_t capacity;
-	struct hash_map_alloc_desc alloc_desc;
 };
 
 struct hash_map_iter {
@@ -34,8 +54,9 @@ struct hash_map_iter {
 	size_t index;
 };
 
-void hash_map_init(struct hash_map *map,
-	const struct hash_map_alloc_desc *alloc_desc);
+void hash_map_init(struct hash_map *map, enum hash_map_key_type key_type,
+	struct hash_map_trait_desc *trait_desc,
+	struct hash_map_alloc_desc *alloc_desc);
 void hash_map_finish(struct hash_map *map);
 void hash_map_insert(struct hash_map *map, char *key, void *value);
 int hash_map_at(const struct hash_map *map, char *key, void **value);

--- a/hash_map.h
+++ b/hash_map.h
@@ -19,11 +19,12 @@ enum hash_map_key_type {
 	HASH_MAP_KEY_TYPE_DOUBLE_LONG,
 	HASH_MAP_KEY_TYPE_CHAR,
 	HASH_MAP_KEY_TYPE_STRING,
-	HASH_MAP_KEY_TYPE_PTR
+	HASH_MAP_KEY_TYPE_PTR,
+	HASH_MAP_KEY_TYPE_CUSTOM
 };
 
 struct hash_map_trait_desc {
-	int (*compare)(void *, void *, size_t);
+	int (*compare)(const void *, const void *, size_t);
 	unsigned long long (*hash)(void *);
 };
 
@@ -31,13 +32,13 @@ struct hash_map_alloc_desc {
 	void *(*malloc_cb)(size_t);
 	void (*free_cb)(void *);
 	void *(*alloc_ctx_cb)(void *, size_t);
-	void (*dealloc_ctx_cb)(void *);
+	void (*dealloc_ctx_cb)(void *, void *);
 	void *ctx;
 };
 
 struct hash_map_entry {
-	const void *key;
-	const void *value;
+	void *key;
+	void *value;
 };
 
 struct hash_map {


### PR DESCRIPTION
Move to 'void *' interface for key and value pairs.
Add helper macros to reduce casting noise.
Split allocation callbacks into heap-related (malloc/free) and context allocation (arena etc.)
Provide interface for using custom hash and compare functions, allowing custom types.
